### PR TITLE
SCR-797: Make the library compatible with python2.6

### DIFF
--- a/requests_aws4auth/__init__.py
+++ b/requests_aws4auth/__init__.py
@@ -208,4 +208,4 @@ del aws4auth
 del aws4signingkey
 del exceptions
 
-__version__ = '0.9'
+__version__ = '0.9.1'

--- a/requests_aws4auth/aws4auth.py
+++ b/requests_aws4auth/aws4auth.py
@@ -228,7 +228,7 @@ class AWS4Auth(AuthBase):
         """
         l = len(args)
         if l not in [2, 4, 5]:
-            msg = 'AWS4Auth() takes 2, 4 or 5 arguments, {} given'.format(l)
+            msg = 'AWS4Auth() takes 2, 4 or 5 arguments, {0} given'.format(l)
             raise TypeError(msg)
         self.access_id = args[0]
         if isinstance(args[1], AWS4SigningKey) and l == 2:
@@ -357,10 +357,10 @@ class AWS4Auth(AuthBase):
         hsh = hmac.new(self.signing_key.key, sig_string, hashlib.sha256)
         sig = hsh.hexdigest()
         auth_str = 'AWS4-HMAC-SHA256 '
-        auth_str += 'Credential={}/{}, '.format(self.access_id,
+        auth_str += 'Credential={0}/{1}, '.format(self.access_id,
                                                 self.signing_key.scope)
-        auth_str += 'SignedHeaders={}, '.format(signed_headers)
-        auth_str += 'Signature={}'.format(sig)
+        auth_str += 'SignedHeaders={0}, '.format(signed_headers)
+        auth_str += 'Signature={0}'.format(sig)
         req.headers['Authorization'] = auth_str
         return req
 
@@ -414,27 +414,27 @@ class AWS4Auth(AuthBase):
         formats = {
             # RFC 7231, e.g. 'Mon, 09 Sep 2011 23:36:00 GMT'
             r'^(?:\w{3}, )?(\d{2}) (\w{3}) (\d{4})\D.*$':
-                lambda m: '{}-{:02d}-{}'.format(
+                lambda m: '{0}-{1:02d}-{2}'.format(
                                           m.group(3),
                                           months.index(m.group(2).lower())+1,
                                           m.group(1)),
             # RFC 850 (e.g. Sunday, 06-Nov-94 08:49:37 GMT)
             # assumes current century
             r'^\w+day, (\d{2})-(\w{3})-(\d{2})\D.*$':
-                lambda m: '{}{}-{:02d}-{}'.format(
+                lambda m: '{0}{1}-{2:02d}-{3}'.format(
                                             str(datetime.date.today().year)[:2],
                                             m.group(3),
                                             months.index(m.group(2).lower())+1,
                                             m.group(1)),
             # C time, e.g. 'Wed Dec 4 00:00:00 2002'
             r'^\w{3} (\w{3}) (\d{1,2}) \d{2}:\d{2}:\d{2} (\d{4})$':
-                lambda m: '{}-{:02d}-{:02d}'.format(
+                lambda m: '{0}-{1:02d}-{2:02d}'.format(
                                               m.group(3),
                                               months.index(m.group(1).lower())+1,
                                               int(m.group(2))),
             # x-amz-date format dates, e.g. 20100325T010101Z
             r'^(\d{4})(\d{2})(\d{2})T\d{6}Z$':
-                lambda m: '{}-{}-{}'.format(*m.groups()),
+                lambda m: '{0}-{1}-{2}'.format(*m.groups()),
             # ISO 8601 / RFC 3339, e.g. '2009-03-25T10:11:12.13-01:00'
             r'^(\d{4}-\d{2}-\d{2})(?:[Tt].*)?$':
                 lambda m: m.group(1),
@@ -567,7 +567,7 @@ class AWS4Auth(AuthBase):
         for hdr in sorted(cano_headers_dict):
             vals = cano_headers_dict[hdr]
             val = ','.join(sorted(vals))
-            cano_headers += '{}:{}\n'.format(hdr, val)
+            cano_headers += '{0}:{1}\n'.format(hdr, val)
             signed_headers_list.append(hdr)
         signed_headers = ';'.join(signed_headers_list)
         return (cano_headers, signed_headers)
@@ -671,6 +671,7 @@ class AWS4Auth(AuthBase):
         Ignore text enclosed in quotes.
 
         """
+        text = text.encode('utf-8')
         return ' '.join(shlex.split(text, posix=False))
 
 

--- a/requests_aws4auth/aws4signingkey.py
+++ b/requests_aws4auth/aws4signingkey.py
@@ -87,7 +87,7 @@ class AWS4SigningKey:
         self.region = region
         self.service = service
         self.date = date or datetime.utcnow().strftime('%Y%m%d')
-        self.scope = '{}/{}/{}/aws4_request'.format(
+        self.scope = '{0}/{1}/{2}/aws4_request'.format(
                                             self.date,
                                             self.region,
                                             self.service)

--- a/requests_aws4auth/test/requests_aws4auth_test.py
+++ b/requests_aws4auth/test/requests_aws4auth_test.py
@@ -182,7 +182,10 @@ def request_from_text(text):
         hdr = hdr.lower()
         vals = headers.setdefault(hdr, [])
         vals.append(val)
-    headers = {hdr: ','.join(sorted(vals)) for hdr, vals in headers.items()}
+
+    for hdr, vals in headers.items():
+        headers[hdr] = ','.join(sorted(vals))
+
     check_url = urlparse(path)
     if check_url.scheme and check_url.netloc:
         # absolute URL in path
@@ -305,7 +308,7 @@ class AWS4_SigningKey_Test(unittest.TestCase):
                                              service, date, intermediates=True)
         for i, hsh in enumerate(result):
             hsh = [ord(x) for x in hsh] if PY2 else list(hsh)
-            self.assertEqual(hsh, expected[i], msg='Item number {}'.format(i))
+            self.assertEqual(hsh, expected[i], msg='Item number {0}'.format(i))
 
     def test_generate_key(self):
         """
@@ -366,7 +369,7 @@ class AWS4Auth_Instantiate_Test(unittest.TestCase):
         if test_date != auth.signing_key.date:
             test_date = datetime.datetime.utcnow().strftime('%Y%m%d')
         self.assertEqual(auth.signing_key.date, test_date)
-        expected = '{}/region/service/aws4_request'.format(test_date)
+        expected = '{0}/region/service/aws4_request'.format(test_date)
         self.assertEqual(auth.signing_key.scope, expected)
 
     def test_instantiate_from_signing_key(self):
@@ -398,7 +401,7 @@ class AWS4Auth_Instantiate_Test(unittest.TestCase):
                         'secret_key',
                         'region',
                         'service')
-        check_set = {'host', 'content-type', 'date', 'x-amz-*'}
+        check_set = set(['host', 'content-type', 'date', 'x-amz-*'])
         self.assertSetEqual(set(auth.include_hdrs), check_set)
 
 


### PR DESCRIPTION
Made string format work with older version of python.
Made changes to tests.
The version will be 0.8.1 (0.8 is the base version and .1 is scout version)

https://goscoutgo.atlassian.net/browse/SCR-797
